### PR TITLE
feat: add a green badge variant and update startup plan details

### DIFF
--- a/src/components/BadgePill.vue
+++ b/src/components/BadgePill.vue
@@ -5,7 +5,7 @@ interface BadgeStylesProps {
 	text?: string;
 }
 
-type BadgeVariant = 'dark' | 'orange' | 'black' | 'pink';
+type BadgeVariant = 'dark' | 'orange' | 'black' | 'pink' | 'green';
 
 interface BadgeProps {
 	styles?: BadgeStylesProps;
@@ -73,7 +73,8 @@ withDefaults(defineProps<BadgeProps>(), {
 
 	&--pink,
 	&--orange,
-	&--dark {
+	&--dark,
+	&--green {
 		background-image: radial-gradient(
 				circle closest-corner at 50% 160%,
 				#8b5261,
@@ -139,6 +140,25 @@ withDefaults(defineProps<BadgeProps>(), {
 			padding-top: 0;
 			box-shadow: none;
 			background-image: none;
+		}
+
+		&--green {
+			background: radial-gradient(
+					44.05% 98.48% at 21.99% 10.19%,
+					rgba(255, 255, 255, 0.4) 0%,
+					rgba(255, 255, 255, 0) 100%
+				),
+				linear-gradient(
+					0deg,
+					rgba(46, 182, 125, 0.75) 0%,
+					rgba(46, 182, 125, 0.75) 100%
+				),
+				radial-gradient(
+					270.11% 383.68% at -68.45% -100.86%,
+					rgba(19, 138, 242, 0.9) 0%,
+					rgba(46, 182, 125, 0.9) 100%
+				);
+			background-blend-mode: normal, overlay, normal;
 		}
 	}
 

--- a/src/components/StaticPlanCard.vue
+++ b/src/components/StaticPlanCard.vue
@@ -372,7 +372,7 @@ import VButton from './VButton.vue';
 import IconSettings from './icons/IconSettings.vue';
 import IconInfo from './icons/IconInfo.vue';
 
-type BadgeVariant = 'dark' | 'orange' | 'black' | 'pink';
+type BadgeVariant = 'dark' | 'orange' | 'black' | 'pink' | 'green';
 type Theme = 'light' | 'dark';
 
 interface StaticPlan {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -339,9 +339,9 @@ export const INFO_CARDS = {
 		},
 		{
 			id: 1,
-			title: 'Startup Plan',
+			title: 'Learn more about the Start-up Plan',
 			description:
-				'For startups with up to 20 employees that raised up to $5M.',
+				"Are you a start-up with fewer than 20 employees? See if you're eligible for our Start-up Plan and get 50% off the Business plan.",
 			button: {
 				text: "Let's start",
 				url: 'https://n8n.notion.site/Supercharge-Your-Startup-with-n8n-e64d5892eb6a43b19a18124595d77625',

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -12,6 +12,7 @@ import VButton from '@/components/VButton.vue';
 import ToggleSwitch from '@/components/ToggleSwitch.vue';
 import TypeformModal from '@/components/TypeformModal.vue';
 import CustomerInfoModal from '@/components/CustomerInfoModal.vue';
+import InfoCardSection from '@/components/InfoCardSection.vue';
 import type { CustomerData } from '@/components/CustomerInfoModal.vue';
 import { STATIC_PLANS, PLANS_FAQ, INFO_CARDS } from '@/constants';
 import { onMounted, ref, watch } from 'vue';
@@ -225,11 +226,7 @@ function redirectToActivate() {
 			: $t('subscription.plans.title')
 	"
 >
-	<DefaultLayout
-		:title="
-			$t('subscription.plans.title')
-		"
-	>
+	<DefaultLayout :title="$t('subscription.plans.title')">
 		<InfoBanner v-if="error" theme="danger" :class="[$style.errorBanner]">
 			{{ $t('error.somethingWentWrong') }}
 		</InfoBanner>
@@ -282,7 +279,10 @@ function redirectToActivate() {
 		<div :class="[$style.plans]">
 			<div :class="[$style.layer]" />
 			<StaticPlanCard
-				:plan="{ ...STATIC_PLANS.startup, price: STATIC_PLANS.startup.basePrice }"
+				:plan="{
+					...STATIC_PLANS.startup,
+					price: STATIC_PLANS.startup.basePrice,
+				}"
 				:isAnnual="isAnnual"
 				:recommended="true"
 				@start-trial="onSubscribe"
@@ -290,11 +290,14 @@ function redirectToActivate() {
 				badgeVariant="pink"
 			/>
 			<StaticPlanCard
-				:plan="{ ...STATIC_PLANS.business, price: STATIC_PLANS.business.basePrice }"
+				:plan="{
+					...STATIC_PLANS.business,
+					price: STATIC_PLANS.business.basePrice,
+				}"
 				:isAnnual="isAnnual"
 				@start-trial="onSubscribe"
 				@contact-us="onBusinessContactUs"
-				badgeVariant="orange"
+				badgeVariant="green"
 			/>
 			<StaticPlanCard
 				:plan="STATIC_PLANS.enterprise"


### PR DESCRIPTION
- Introduced a new "green" badge variant with custom styles.
- Updated startup plan title and description for clarity.
- Changed plan card badge variant to "green" on the home view.