### PR TITLE
fix: upgrade vue to 3.5 and pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deployToCloudFlarePages.yml
+++ b/.github/workflows/deployToCloudFlarePages.yml
@@ -12,10 +12,10 @@ jobs:
         env:
             BRANCH_NAME: ${{ github.ref_name }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
               with:
                   node-version: 20.x
                   cache: npm
@@ -34,7 +34,7 @@ jobs:
 
             - name: Deploy to Cloudflare Pages (Production)
               if: ${{ env.BRANCH_NAME == 'main' }}
-              uses: cloudflare/wrangler-action@v3
+              uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -42,7 +42,7 @@ jobs:
 
             - name: Deploy to Cloudflare Pages (Staging)
               if: ${{ env.BRANCH_NAME == 'staging' }}
-              uses: cloudflare/wrangler-action@v3
+              uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "subscription-app",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "subscription-app",
-			"version": "0.12.0",
+			"version": "0.13.0",
 			"dependencies": {
 				"floating-vue": "^5.2.2",
 				"pinia": "^2.0.26",
-				"vue": "^3.2.45",
+				"vue": "^3.5.0",
 				"vue-i18n": "^9.9.1",
 				"vue-router": "^4.1.6"
 			},
@@ -66,11 +66,20 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-			"dev": true,
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -161,14 +170,31 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-			"integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.29.0"
+			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@colors/colors": {
@@ -1252,10 +1278,10 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.9",
@@ -2381,49 +2407,65 @@
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
-			"integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+			"integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.16.4",
-				"@vue/shared": "3.2.45",
+				"@babel/parser": "^7.29.3",
+				"@vue/shared": "3.5.34",
+				"entities": "^7.0.1",
 				"estree-walker": "^2.0.2",
-				"source-map": "^0.6.1"
+				"source-map-js": "^1.2.1"
+			}
+		},
+		"node_modules/@vue/compiler-core/node_modules/entities": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/@vue/compiler-dom": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
-			"integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+			"integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-core": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-core": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
-			"integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+			"integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.45",
-				"@vue/compiler-dom": "3.2.45",
-				"@vue/compiler-ssr": "3.2.45",
-				"@vue/reactivity-transform": "3.2.45",
-				"@vue/shared": "3.2.45",
+				"@babel/parser": "^7.29.3",
+				"@vue/compiler-core": "3.5.34",
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/compiler-ssr": "3.5.34",
+				"@vue/shared": "3.5.34",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7",
-				"postcss": "^8.1.10",
-				"source-map": "^0.6.1"
+				"magic-string": "^0.30.21",
+				"postcss": "^8.5.14",
+				"source-map-js": "^1.2.1"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
-			"integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+			"integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/devtools-api": {
@@ -2471,60 +2513,54 @@
 			}
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
-			"integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+			"integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/shared": "3.2.45"
-			}
-		},
-		"node_modules/@vue/reactivity-transform": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
-			"integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
-			"dependencies": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.45",
-				"@vue/shared": "3.2.45",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7"
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
-			"integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+			"integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/reactivity": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
-			"integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+			"integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/runtime-core": "3.2.45",
-				"@vue/shared": "3.2.45",
-				"csstype": "^2.6.8"
+				"@vue/reactivity": "3.5.34",
+				"@vue/runtime-core": "3.5.34",
+				"@vue/shared": "3.5.34",
+				"csstype": "^3.2.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
-			"integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+			"integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-ssr": "3.5.34",
+				"@vue/shared": "3.5.34"
 			},
 			"peerDependencies": {
-				"vue": "3.2.45"
+				"vue": "3.5.34"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
-			"integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+			"integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+			"license": "MIT"
 		},
 		"node_modules/@vue/test-utils": {
 			"version": "2.2.4",
@@ -3539,9 +3575,10 @@
 			"dev": true
 		},
 		"node_modules/csstype": {
-			"version": "2.6.21",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-			"integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+			"license": "MIT"
 		},
 		"node_modules/cypress": {
 			"version": "11.2.0",
@@ -6475,11 +6512,12 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"license": "MIT",
 			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"node_modules/make-error": {
@@ -7344,9 +7382,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-			"integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8177,6 +8215,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8193,7 +8232,8 @@
 		"node_modules/sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
 		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
@@ -9427,15 +9467,24 @@
 			}
 		},
 		"node_modules/vue": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
-			"integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+			"integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.2.45",
-				"@vue/compiler-sfc": "3.2.45",
-				"@vue/runtime-dom": "3.2.45",
-				"@vue/server-renderer": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/compiler-sfc": "3.5.34",
+				"@vue/runtime-dom": "3.5.34",
+				"@vue/server-renderer": "3.5.34",
+				"@vue/shared": "3.5.34"
+			},
+			"peerDependencies": {
+				"typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/vue-eslint-parser": {
@@ -9756,21 +9805,6 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
-		"node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/yargs": {
 			"version": "17.6.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
@@ -9855,11 +9889,15 @@
 				"@babel/highlight": "^7.18.6"
 			}
 		},
+		"@babel/helper-string-parser": {
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
+		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.19.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-			"dev": true
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="
 		},
 		"@babel/highlight": {
 			"version": "7.18.6",
@@ -9931,9 +9969,21 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.20.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-			"integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA=="
+			"version": "7.29.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+			"integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+			"requires": {
+				"@babel/types": "^7.29.0"
+			}
+		},
+		"@babel/types": {
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"requires": {
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5"
+			}
 		},
 		"@colors/colors": {
 			"version": "1.5.0",
@@ -10618,10 +10668,9 @@
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.9",
@@ -11288,49 +11337,56 @@
 			}
 		},
 		"@vue/compiler-core": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
-			"integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+			"integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
 			"requires": {
-				"@babel/parser": "^7.16.4",
-				"@vue/shared": "3.2.45",
+				"@babel/parser": "^7.29.3",
+				"@vue/shared": "3.5.34",
+				"entities": "^7.0.1",
 				"estree-walker": "^2.0.2",
-				"source-map": "^0.6.1"
+				"source-map-js": "^1.2.1"
+			},
+			"dependencies": {
+				"entities": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+					"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
+				}
 			}
 		},
 		"@vue/compiler-dom": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
-			"integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+			"integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
 			"requires": {
-				"@vue/compiler-core": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-core": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"@vue/compiler-sfc": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
-			"integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+			"integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
 			"requires": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.45",
-				"@vue/compiler-dom": "3.2.45",
-				"@vue/compiler-ssr": "3.2.45",
-				"@vue/reactivity-transform": "3.2.45",
-				"@vue/shared": "3.2.45",
+				"@babel/parser": "^7.29.3",
+				"@vue/compiler-core": "3.5.34",
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/compiler-ssr": "3.5.34",
+				"@vue/shared": "3.5.34",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7",
-				"postcss": "^8.1.10",
-				"source-map": "^0.6.1"
+				"magic-string": "^0.30.21",
+				"postcss": "^8.5.14",
+				"source-map-js": "^1.2.1"
 			}
 		},
 		"@vue/compiler-ssr": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
-			"integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+			"integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
 			"requires": {
-				"@vue/compiler-dom": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"@vue/devtools-api": {
@@ -11360,57 +11416,46 @@
 			}
 		},
 		"@vue/reactivity": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.45.tgz",
-			"integrity": "sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+			"integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
 			"requires": {
-				"@vue/shared": "3.2.45"
-			}
-		},
-		"@vue/reactivity-transform": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
-			"integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
-			"requires": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.45",
-				"@vue/shared": "3.2.45",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7"
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"@vue/runtime-core": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.45.tgz",
-			"integrity": "sha512-gzJiTA3f74cgARptqzYswmoQx0fIA+gGYBfokYVhF8YSXjWTUA2SngRzZRku2HbGbjzB6LBYSbKGIaK8IW+s0A==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+			"integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
 			"requires": {
-				"@vue/reactivity": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/reactivity": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"@vue/runtime-dom": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.45.tgz",
-			"integrity": "sha512-cy88YpfP5Ue2bDBbj75Cb4bIEZUMM/mAkDMfqDTpUYVgTf/kuQ2VQ8LebuZ8k6EudgH8pYhsGWHlY0lcxlvTwA==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+			"integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
 			"requires": {
-				"@vue/runtime-core": "3.2.45",
-				"@vue/shared": "3.2.45",
-				"csstype": "^2.6.8"
+				"@vue/reactivity": "3.5.34",
+				"@vue/runtime-core": "3.5.34",
+				"@vue/shared": "3.5.34",
+				"csstype": "^3.2.3"
 			}
 		},
 		"@vue/server-renderer": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.45.tgz",
-			"integrity": "sha512-ebiMq7q24WBU1D6uhPK//2OTR1iRIyxjF5iVq/1a5I1SDMDyDu4Ts6fJaMnjrvD3MqnaiFkKQj+LKAgz5WIK3g==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+			"integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
 			"requires": {
-				"@vue/compiler-ssr": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-ssr": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"@vue/shared": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
-			"integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg=="
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+			"integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA=="
 		},
 		"@vue/test-utils": {
 			"version": "2.2.4",
@@ -12131,9 +12176,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.21",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
-			"integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
 		},
 		"cypress": {
 			"version": "11.2.0",
@@ -14201,11 +14246,11 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
 			"requires": {
-				"sourcemap-codec": "^1.4.8"
+				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
 		"make-error": {
@@ -14839,9 +14884,9 @@
 			}
 		},
 		"postcss": {
-			"version": "8.5.4",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-			"integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+			"version": "8.5.14",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+			"integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
 			"requires": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -15386,7 +15431,8 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-js": {
 			"version": "1.2.1",
@@ -15396,7 +15442,8 @@
 		"sourcemap-codec": {
 			"version": "1.4.8",
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+			"dev": true
 		},
 		"spdx-correct": {
 			"version": "3.1.1",
@@ -16212,15 +16259,15 @@
 			}
 		},
 		"vue": {
-			"version": "3.2.45",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.2.45.tgz",
-			"integrity": "sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==",
+			"version": "3.5.34",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+			"integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
 			"requires": {
-				"@vue/compiler-dom": "3.2.45",
-				"@vue/compiler-sfc": "3.2.45",
-				"@vue/runtime-dom": "3.2.45",
-				"@vue/server-renderer": "3.2.45",
-				"@vue/shared": "3.2.45"
+				"@vue/compiler-dom": "3.5.34",
+				"@vue/compiler-sfc": "3.5.34",
+				"@vue/runtime-dom": "3.5.34",
+				"@vue/server-renderer": "3.5.34",
+				"@vue/shared": "3.5.34"
 			}
 		},
 		"vue-eslint-parser": {
@@ -16440,14 +16487,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"optional": true,
-			"peer": true
 		},
 		"yargs": {
 			"version": "17.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	"dependencies": {
 		"floating-vue": "^5.2.2",
 		"pinia": "^2.0.26",
-		"vue": "^3.2.45",
+		"vue": "^3.5.0",
 		"vue-i18n": "^9.9.1",
 		"vue-router": "^4.1.6"
 	},


### PR DESCRIPTION
Vue 3.2 reached end-of-life and no longer receives security updates; bump to ^3.5.0 (resolves to 3.5.34). Pin actions/checkout, actions/setup-node, and cloudflare/wrangler-action to commit SHAs to mitigate supply-chain risk from mutable tag references.