### PR TITLE
fix(plans): per-plan CTA attribution for Startup vs Business

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -121,8 +121,14 @@ function trackCheckout(data: {
 	telemetry.track('User submitted payment details successfully', params);
 }
 
-async function onSubscribe(priceId: string, executions: number) {
-	trackButtonClicked('business_get_started');
+async function onSubscribe(
+	priceId: string,
+	executions: number,
+	plan: 'startup' | 'business'
+) {
+	trackButtonClicked(
+		plan === 'startup' ? 'startup_get_started' : 'business_get_started'
+	);
 
 	if (!window.Paddle) {
 		ElNotification({
@@ -166,8 +172,10 @@ async function handleCustomerInfoSubmit(customerData: CustomerData) {
 	}
 }
 
-function onBusinessContactUs() {
-	trackButtonClicked('business_contact_us');
+function onBusinessContactUs(plan: 'startup' | 'business') {
+	trackButtonClicked(
+		plan === 'startup' ? 'startup_contact_us' : 'business_contact_us'
+	);
 	showBusinessModal.value = true;
 }
 
@@ -285,8 +293,11 @@ function redirectToActivate() {
 				}"
 				:isAnnual="isAnnual"
 				:recommended="true"
-				@start-trial="onSubscribe"
-				@contact-us="onBusinessContactUs"
+				@start-trial="
+					(priceId, executions) =>
+						onSubscribe(priceId, executions, 'startup')
+				"
+				@contact-us="() => onBusinessContactUs('startup')"
 				badgeVariant="pink"
 			/>
 			<StaticPlanCard
@@ -295,8 +306,11 @@ function redirectToActivate() {
 					price: STATIC_PLANS.business.basePrice,
 				}"
 				:isAnnual="isAnnual"
-				@start-trial="onSubscribe"
-				@contact-us="onBusinessContactUs"
+				@start-trial="
+					(priceId, executions) =>
+						onSubscribe(priceId, executions, 'business')
+				"
+				@contact-us="() => onBusinessContactUs('business')"
 				badgeVariant="green"
 			/>
 			<StaticPlanCard


### PR DESCRIPTION
## What

On plans.n8n.io, the Startup and Business plan cards both wired their **Get started** and **Contact sales** buttons to handlers that hard-coded the RudderStack `action` property to `business_get_started` / `business_contact_us`. Startup and Business clicks therefore collapsed into a single label in BigQuery (`rudder_cloud_fe` event tables, event *"User clicked button on plans page"*), making per-plan CTA attribution impossible.

The `action` union type already declared `startup_get_started` and `startup_contact_us` — they were just never emitted.

## Fix

Pass the plan identity through from each card instance in `HomeView.vue` into the shared `onSubscribe` / `onBusinessContactUs` handlers, so:

- Startup **Get started** → `startup_get_started`
- Business **Get started** → `business_get_started`
- Startup **Contact sales** → `startup_contact_us`
- Business **Contact sales** → `business_contact_us`

The shared `StaticPlanCard` component (also used by the enterprise/community cards) is untouched — the parent already renders each card explicitly, so plan identity is injected at the call site rather than threaded through a new prop/emit.

`onBusinessContactUs` had the same bug for the Startup card's contact-us path and is fixed consistently.

## ⚠️ Reporting semantics change (from merge date)

Downstream BQ queries and dashboards currently assume `business_get_started` (and `business_contact_us`) cover **both** plans. After this merges, Startup volume splits out into `startup_get_started` / `startup_contact_us`, so Business-labelled counts will drop. Any consumer aggregating plan-CTA clicks must **sum both labels** (or add the new ones) to keep pre/post-merge numbers comparable.

## Verification

- `npm run lint` — passes (auto-fix applied)
- `npm run type-check` (`vue-tsc`) — passes; validates the inline template handlers against the card's emit signatures
- `npm run test:unit` — repo has **no unit test files** (pre-existing), so no test to run/regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)